### PR TITLE
Update trim_galore version

### DIFF
--- a/config/RNAconfig.yaml
+++ b/config/RNAconfig.yaml
@@ -19,7 +19,7 @@ gtf: '/proj/seq/data/GRCh38_GENCODE/gencode.v32.primary_assembly.annotation.gtf'
 
 ## Software versions
 fastqcVers: "0.11.5"
-trimVers: "0.4.3"
+trimVers: "0.6.7"
 salmonVers: "1.4.0"
 hisatVers: "2.1.0"
 samtoolsVers: "1.9"


### PR DESCRIPTION
Update trim_galore version for compatibility with latest cutadapt version (4.1 at this time).
Version 0.4.3 produced this error (cutadapt: error: unrecognized arguments: -f) (exit signal 512)
See this issue for more information: https://github.com/FelixKrueger/TrimGalore/issues/68