### PR TITLE
Update ChIPconfig.yaml

### DIFF
--- a/config/ChIPconfig.yaml
+++ b/config/ChIPconfig.yaml
@@ -17,7 +17,7 @@ bwamem: '/proj/seq/data/HG19_UCSC/Sequence/BWAIndex/genome.fa'
 
 ## Software versions
 fastqcVers: "0.11.5"
-trimVers: "0.4.3"
+trimVers: "0.6.7"
 bwaVers: "0.7.17"
 samtoolsVers: "1.9"
 javaVers: "10.0.2"


### PR DESCRIPTION
trim_galore needs to be updated to a newer version. 0.6.7 is the most recent update.